### PR TITLE
The message header '--batch_batchId' is invalid

### DIFF
--- a/src/webapi.ts
+++ b/src/webapi.ts
@@ -656,6 +656,7 @@ export function batchOperation(apiConfig: WebApiConfig, batchId: string, changeS
         body.push('');
         body.push(`GET ${apiConfig.url}/${get} HTTP/1.1`);
         body.push('Accept: application/json');
+        body.push('');
     }
 
     if (batchGets.length > 0) {


### PR DESCRIPTION
Add a linebreak at the end of batch gets to allow CRM to correctly parse the request

Fixes #23